### PR TITLE
feat: patient-professional linkage and document retrieval

### DIFF
--- a/src/documents/documents.service.ts
+++ b/src/documents/documents.service.ts
@@ -106,6 +106,32 @@ export class DocumentsService {
     });
   }
 
+  async getDocumentsByPatient(patientId: number, patientType: string) {
+    return this.documentRepository.find({
+      where: {
+        createdById: patientId,
+        createdByType: patientType,
+        status: Not(EventStatus.CANCELED),
+      },
+      order: {
+        documentDate: 'DESC',
+      },
+      select: [
+        'id',
+        'title',
+        'description',
+        'fileName',
+        'mimeType',
+        'fileSize',
+        'documentDate',
+        'date',
+        'status',
+        'createdAt',
+        'updatedAt',
+      ],
+    });
+  }
+
   async getDocumentById(id: number) {
     // IMPORTANTE: Incluir fileContent explícitamente porque TypeORM no carga campos TEXT grandes por defecto
     const doc = await this.documentRepository.findOne({

--- a/src/professionals/dto/create-patient-professional.dto.ts
+++ b/src/professionals/dto/create-patient-professional.dto.ts
@@ -1,0 +1,11 @@
+import { IsIn, IsNotEmpty, IsNumber } from 'class-validator';
+
+export class CreatePatientProfessionalDto {
+  @IsNumber()
+  @IsNotEmpty()
+  patientId: number;
+
+  @IsIn(['user', 'dependent'])
+  @IsNotEmpty()
+  patientType: string;
+}

--- a/src/professionals/entities/patient-professional.entity.ts
+++ b/src/professionals/entities/patient-professional.entity.ts
@@ -1,0 +1,32 @@
+import {
+  Column,
+  Entity,
+  JoinColumn,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+  Unique,
+} from 'typeorm';
+import { ProfessionalUser } from './professional-user.entity';
+
+@Entity()
+@Unique(['professional', 'patientId', 'patientType'])
+export class PatientProfessional {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @ManyToOne(() => ProfessionalUser, { eager: false })
+  @JoinColumn({ name: 'professional_id' })
+  professional: ProfessionalUser;
+
+  @Column({ name: 'professional_id' })
+  professionalId: number;
+
+  @Column()
+  patientId: number;
+
+  @Column({ type: 'enum', enum: ['user', 'dependent'] })
+  patientType: string;
+
+  @Column({ type: 'timestamp', default: () => 'CURRENT_TIMESTAMP' })
+  createdAt: Date;
+}

--- a/src/professionals/professionals.controller.ts
+++ b/src/professionals/professionals.controller.ts
@@ -5,8 +5,11 @@ import {
   Get,
   HttpException,
   HttpStatus,
+  Param,
+  ParseIntPipe,
   Post,
   Put,
+  Query,
   Req,
   UseGuards,
   UsePipes,
@@ -22,6 +25,7 @@ import { MailService } from 'src/mail/mail.service';
 import { Role } from 'src/roles/enums/role.enum';
 import RoleGuard from 'src/roles/guards/role.guards';
 import { UsersService } from 'src/users/users.service';
+import { CreatePatientProfessionalDto } from './dto/create-patient-professional.dto';
 import { CreateProfessionalSpecializationDto } from './dto/create-professional-specialization.dto';
 import { CreateProfessionalDto } from './dto/create-professional.dto';
 import { Professionals } from './entities/my-professional.entity';
@@ -179,6 +183,78 @@ export class ProfessionalsController {
       request.params.id,
       true,
     );
+  }
+
+  // ---- Patient-Professional endpoints ----
+
+  @UseGuards(RoleGuard([Role.Professional]))
+  @UsePipes(ValidationPipe)
+  @Post('/patients')
+  async linkPatient(
+    @Body() dto: CreatePatientProfessionalDto,
+    @Req() request,
+  ) {
+    try {
+      const link = await this.professionalsService.linkPatient(
+        request.user.id,
+        dto,
+      );
+      return { status: HttpStatus.CREATED, id: link.id };
+    } catch (error) {
+      throw new HttpException(
+        { message: error.message || 'No se pudo vincular al paciente', status: 'error' },
+        HttpStatus.BAD_REQUEST,
+      );
+    }
+  }
+
+  @UseGuards(RoleGuard([Role.Professional]))
+  @Delete('/patients/:patientId')
+  async unlinkPatient(
+    @Param('patientId', ParseIntPipe) patientId: number,
+    @Query('patientType') patientType: string,
+    @Req() request,
+  ) {
+    try {
+      await this.professionalsService.unlinkPatient(
+        request.user.id,
+        patientId,
+        patientType,
+      );
+      return { status: HttpStatus.OK, message: 'Paciente desvinculado' };
+    } catch (error) {
+      throw new HttpException(
+        { message: error.message || 'No se pudo desvincular al paciente', status: 'error' },
+        HttpStatus.BAD_REQUEST,
+      );
+    }
+  }
+
+  @UseGuards(RoleGuard([Role.Professional]))
+  @Get('/patients')
+  async getPatients(@Req() request) {
+    return this.professionalsService.getPatients(request.user.id);
+  }
+
+  @UseGuards(RoleGuard([Role.Professional]))
+  @Get('/patients/:patientId/documents')
+  async getPatientDocuments(
+    @Param('patientId', ParseIntPipe) patientId: number,
+    @Query('patientType') patientType: string,
+    @Req() request,
+  ) {
+    try {
+      return await this.professionalsService.getPatientDocuments(
+        request.user.id,
+        patientId,
+        patientType,
+      );
+    } catch (error) {
+      throw new HttpException(
+        { message: error.message || 'No se pudieron obtener los documentos', status: 'error' },
+        HttpStatus.BAD_REQUEST,
+      );
+    }
   }
 
   @Get('/monthly-quantity')

--- a/src/professionals/professionals.module.ts
+++ b/src/professionals/professionals.module.ts
@@ -6,7 +6,10 @@ import { ProfessionalUser } from './entities/professional-user.entity';
 import { UsersModule } from 'src/users/users.module';
 import { ProfessionalSpecialization } from './entities/professional-specialization.entity';
 import { Professionals } from './entities/my-professional.entity';
+import { PatientProfessional } from './entities/patient-professional.entity';
 import { MailModule } from 'src/mail/mail.module';
+import { DocumentsModule } from 'src/documents/documents.module';
+import { FamilyGroupsModule } from 'src/family-groups/family-groups.module';
 
 @Module({
   imports: [
@@ -14,9 +17,12 @@ import { MailModule } from 'src/mail/mail.module';
       ProfessionalUser,
       ProfessionalSpecialization,
       Professionals,
+      PatientProfessional,
     ]),
     UsersModule,
     MailModule,
+    DocumentsModule,
+    FamilyGroupsModule,
   ],
   providers: [ProfessionalsService],
   exports: [ProfessionalsService],

--- a/src/professionals/professionals.service.ts
+++ b/src/professionals/professionals.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { BadRequestException, Injectable, NotFoundException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { hashSync } from 'bcrypt';
 import { User } from '../users/entities/user.entity';
@@ -7,10 +7,15 @@ import { Like, Not, Repository } from 'typeorm';
 import { CreateMyProfessionalDto } from './dto/create-my-professional.dto';
 import { CreateProfessionalSpecializationDto } from './dto/create-professional-specialization.dto';
 import { CreateProfessionalDto } from './dto/create-professional.dto';
+import { CreatePatientProfessionalDto } from './dto/create-patient-professional.dto';
 import { Professionals } from './entities/my-professional.entity';
 import { ProfessionalSpecialization } from './entities/professional-specialization.entity';
 import { ProfessionalUser } from './entities/professional-user.entity';
+import { PatientProfessional } from './entities/patient-professional.entity';
 import { Role } from 'src/roles/enums/role.enum';
+import { DocumentsService } from 'src/documents/documents.service';
+import { UsersService } from 'src/users/users.service';
+import { FamilyGroupsService } from 'src/family-groups/family-groups.service';
 
 @Injectable()
 export class ProfessionalsService {
@@ -21,6 +26,11 @@ export class ProfessionalsService {
     private myProfessionalsRepository: Repository<Professionals>,
     @InjectRepository(ProfessionalSpecialization)
     private professionalSpecializationsRepository: Repository<ProfessionalSpecialization>,
+    @InjectRepository(PatientProfessional)
+    private patientProfessionalRepository: Repository<PatientProfessional>,
+    private readonly documentsService: DocumentsService,
+    private readonly usersService: UsersService,
+    private readonly familyGroupsService: FamilyGroupsService,
   ) {}
 
   async createMyProfessional(
@@ -156,5 +166,89 @@ export class ProfessionalsService {
     return this.professionalUserRepository.find({
       select: { createdAt: true },
     });
+  }
+
+  // ---- Patient-Professional linkage ----
+
+  async linkPatient(
+    professionalId: number,
+    dto: CreatePatientProfessionalDto,
+  ): Promise<PatientProfessional> {
+    const existing = await this.patientProfessionalRepository.findOne({
+      where: {
+        professionalId,
+        patientId: dto.patientId,
+        patientType: dto.patientType,
+      },
+    });
+    if (existing) {
+      throw new BadRequestException('El paciente ya está vinculado');
+    }
+    const link = this.patientProfessionalRepository.create({
+      professionalId,
+      patientId: dto.patientId,
+      patientType: dto.patientType,
+    });
+    return this.patientProfessionalRepository.save(link);
+  }
+
+  async unlinkPatient(
+    professionalId: number,
+    patientId: number,
+    patientType: string,
+  ) {
+    const link = await this.patientProfessionalRepository.findOne({
+      where: { professionalId, patientId, patientType },
+    });
+    if (!link) {
+      throw new NotFoundException('El vínculo no existe');
+    }
+    return this.patientProfessionalRepository.remove(link);
+  }
+
+  async getPatients(professionalId: number) {
+    const links = await this.patientProfessionalRepository.find({
+      where: { professionalId },
+      order: { createdAt: 'DESC' },
+    });
+
+    const enriched = await Promise.all(
+      links.map(async (link) => {
+        let firstName = '';
+        let lastName = '';
+        if (link.patientType === 'user') {
+          const user = await this.usersService.getUserById(link.patientId);
+          if (user) {
+            firstName = user.firstName;
+            lastName = user.lastName;
+          }
+        } else if (link.patientType === 'dependent') {
+          const dep = await this.familyGroupsService.getDependentById(link.patientId);
+          if (dep) {
+            firstName = dep.firstName;
+            lastName = dep.lastName;
+          }
+        }
+        return { ...link, firstName, lastName };
+      }),
+    );
+
+    return enriched;
+  }
+
+  async getPatientDocuments(
+    professionalId: number,
+    patientId: number,
+    patientType: string,
+  ) {
+    const link = await this.patientProfessionalRepository.findOne({
+      where: { professionalId, patientId, patientType },
+    });
+    if (!link) {
+      throw new NotFoundException(
+        'No tiene vínculo con este paciente',
+      );
+    }
+    return this.documentsService.getDocumentsByPatient(patientId, patientType);
   }
 }

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -35,7 +35,7 @@ export class UsersService {
 
   async getUserByDni(dni: string) {
     return await this.userRepository.findOne({
-      select: { firstName: true, lastName: true, dni: true },
+      select: { id: true, firstName: true, lastName: true, dni: true },
       where: { dni },
     });
   }


### PR DESCRIPTION
## Summary
- Adds `PatientProfessional` entity + DTO for linking patients to professionals
- Extends `professionals` controller/service with patient linkage and document retrieval endpoints
- Updates `documents.service` to support retrieval flow needed by the professional view

## Test plan
- [ ] Create a patient-professional link via the new endpoint
- [ ] Retrieve a patient's documents from the professional account
- [ ] Verify existing professional/users flows still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)