### PR TITLE
feat(meds-event): add GET/PATCH endpoints and fix med relation update

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -19,6 +19,7 @@ async function bootstrap() {
       'http://localhost:8100',
       'http://localhost:4200',
       'http://localhost:54733', // back-office dev origin
+      'http://10.0.2.2:8100',  // emulador Android con live reload
       'capacitor://localhost',
       'ionic://localhost',
       'http://localhost',

--- a/src/meds/meds-event/meds-event.controller.ts
+++ b/src/meds/meds-event/meds-event.controller.ts
@@ -6,6 +6,7 @@ import {
   HttpStatus,
   Param,
   ParseIntPipe,
+  Patch,
   Post,
   Req,
   UseGuards,
@@ -71,6 +72,40 @@ export class MedsEventController {
         HttpStatus.BAD_REQUEST,
       );
     }
+  }
+
+  @Get(':id')
+  async getMedEventById(@Param('id', ParseIntPipe) id: number) {
+    const medEvent = await this.medsEventService.getMedEventById(id);
+    if (!medEvent) {
+      throw new HttpException(
+        { message: 'Recordatorio no encontrado', status: 'error' },
+        HttpStatus.NOT_FOUND,
+      );
+    }
+    return medEvent;
+  }
+
+  @Patch(':id')
+  @UsePipes(new ValidationPipe({ transform: true, whitelist: true }))
+  async updateMedEvent(
+    @Param('id', ParseIntPipe) id: number,
+    @Body() updateData: Partial<CreateMedEventDto>,
+  ) {
+    await this.medsEventService.updateMedEvent(id, updateData);
+    return { status: HttpStatus.OK };
+  }
+
+  @Patch(':id/cancel')
+  async cancelMedEvent(@Param('id', ParseIntPipe) id: number) {
+    await this.medsEventService.cancelMedEvent(id);
+    return { status: HttpStatus.OK };
+  }
+
+  @Patch(':id/confirm')
+  async confirmMedEvent(@Param('id', ParseIntPipe) id: number) {
+    await this.medsEventService.confirmMedEvent(id);
+    return { status: HttpStatus.OK };
   }
 
   @Post('dependent/:id')

--- a/src/meds/meds-event/meds-event.service.ts
+++ b/src/meds/meds-event/meds-event.service.ts
@@ -212,8 +212,10 @@ export class MedsEventService {
   }
 
   async updateMedEvent(id: number, updateData: Partial<CreateMedEventDto>) {
+    const { medId, ...rest } = updateData as any;
     return this.medEventRepository.update(id, {
-      ...updateData,
+      ...rest,
+      ...(medId ? { med: { id: medId } as any } : {}),
       updatedAt: new Date(),
     });
   }


### PR DESCRIPTION
- Add GET /meds-event/:id, PATCH /meds-event/:id, PATCH /meds-event/:id/cancel and PATCH /meds-event/:id/confirm controller routes
- Fix updateMedEvent service to map medId → med relation so TypeORM persists the medication change
- Add http://10.0.2.2:8100 to CORS origins for Android emulator live reload