### PR TITLE
feat(documents): fileContent en listado (thumbnails) + reemplazo de imagen al editar

### DIFF
--- a/src/documents/documents.service.ts
+++ b/src/documents/documents.service.ts
@@ -71,6 +71,7 @@ export class DocumentsService {
         'fileName',
         'mimeType',
         'fileSize',
+        'fileContent', // necesario para renderizar el thumbnail de imágenes en el listado
         'documentDate',
         'date',
         'status',
@@ -97,6 +98,7 @@ export class DocumentsService {
         'fileName',
         'mimeType',
         'fileSize',
+        'fileContent', // necesario para renderizar el thumbnail de imágenes en el listado
         'documentDate',
         'date',
         'status',
@@ -226,6 +228,7 @@ export class DocumentsService {
         'fileName',
         'mimeType',
         'fileSize',
+        'fileContent', // necesario para renderizar el thumbnail de imágenes en el listado
         'documentDate',
         'date',
         'status',

--- a/src/documents/documents.service.ts
+++ b/src/documents/documents.service.ts
@@ -171,6 +171,14 @@ export class DocumentsService {
     if (editDto.date) document.date = new Date(editDto.date);
     if (editDto.status) document.status = editDto.status;
 
+    // Reemplazo de la imagen/archivo (opcional)
+    if (editDto.fileContent) {
+      document.fileContent = editDto.fileContent;
+      if (editDto.fileName) document.fileName = editDto.fileName;
+      if (editDto.mimeType) document.mimeType = editDto.mimeType;
+      if (editDto.fileSize !== undefined) document.fileSize = editDto.fileSize;
+    }
+
     document.updatedAt = new Date();
     return this.documentRepository.save(document);
   }

--- a/src/documents/dto/edit-document.dto.ts
+++ b/src/documents/dto/edit-document.dto.ts
@@ -1,4 +1,4 @@
-import { IsDateString, IsOptional, IsString } from 'class-validator';
+import { IsDateString, IsNumber, IsOptional, IsString } from 'class-validator';
 
 export class EditDocumentDTO {
   @IsOptional()
@@ -20,4 +20,21 @@ export class EditDocumentDTO {
   @IsOptional()
   @IsString()
   status?: string;
+
+  // Reemplazo de archivo (opcional, al editar la imagen del documento)
+  @IsOptional()
+  @IsString()
+  fileContent?: string; // Base64
+
+  @IsOptional()
+  @IsString()
+  fileName?: string;
+
+  @IsOptional()
+  @IsString()
+  mimeType?: string;
+
+  @IsOptional()
+  @IsNumber()
+  fileSize?: number;
 }


### PR DESCRIPTION
## Resumen
Soporte de backend para la feature de documentos del frontend (ya mergeada a `dev` en `sigsa-frontend`): miniaturas en el listado y reemplazo de la imagen al editar.

## Cambios
- **Listado**: las queries de documentos (usuario / dependiente / grupo) ahora seleccionan `fileContent`, para que el frontend pueda mostrar la miniatura de imagen en cada fila del listado.
- **Edición**: `EditDocumentDTO` acepta `fileContent/fileName/mimeType/fileSize` (opcionales) y `updateDocument` los persiste solo cuando se envía un archivo nuevo, permitiendo cambiar la imagen del documento al editar.

## Notas
- Acompaña al frontend ya mergeado en `dev`. Sin esto, los thumbnails y el cambio de imagen no funcionan end-to-end.
- Build OK (`tsc -p tsconfig.build.json`).
- Rama limpia armada desde `dev` (solo estos 2 commits de documentos; el resto del trabajo previo ya estaba en `dev`).
